### PR TITLE
Data state and storage

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -11,7 +11,7 @@ class _HomeState extends State<Home> {
   //create calendar object
   CalendarController _controller;
   //create list of events (map type)
-  Map<DateTime, List<dynamic>> _events;
+  Map<DateTime, Map<String, int>> _events;
   //creates controller for add button
   TextEditingController _eventController;
   //creates list for the events of a specific day
@@ -36,7 +36,7 @@ class _HomeState extends State<Home> {
     setState(() {
       //decodeMap to get events as a String or an empty Map back
       //set this to the _events in use
-      _events = Map<DateTime, List<dynamic>>.from(
+      _events = Map<DateTime, Map<String, int>>.from(
           decodeMap(json.decode(prefs.getString("events") ?? "{}")));
     });
   }
@@ -52,7 +52,9 @@ class _HomeState extends State<Home> {
           children: <Widget>[
             //put the calendar on the screen
             TableCalendar(
-              events: _events,
+              // Currently very ugly
+              events: _events
+                  .map((key, value) => MapEntry(key, [value.toString()])),
               //sets calendar style
               calendarStyle:
                   CalendarStyle(selectedColor: Theme.of(context).primaryColor),
@@ -64,24 +66,6 @@ class _HomeState extends State<Home> {
                   _selectedEvents = events;
                 });
               },
-              builders: CalendarBuilders(
-                //builder for the selected day
-                selectedDayBuilder: (context, date, events) => Container(
-                  //aligns date in the center of its box
-                  alignment: Alignment.center,
-                  //deals with the date's box and sets it's appearance back to
-                  //when selectedDayBuilder was not created as it overrides
-                  //calendarStyle (decoration and child)
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).primaryColor,
-                    shape: BoxShape.circle,
-                  ),
-                  child: Text(
-                    date.day.toString(),
-                    style: TextStyle(color: Colors.white),
-                  ),
-                ),
-              ),
             ),
             //lists out the _selectedEvents (events of the day) on the screen
             //below the calendar
@@ -95,68 +79,38 @@ class _HomeState extends State<Home> {
           backgroundColor: Colors.green,
           hoverColor: Colors.blue,
           onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => Test()),
-            );
+            print(_controller.selectedDay);
+            setState(() {
+              _events[_controller.selectedDay] = {"anxiety": 5, "sadness": 3};
+              prefs.setString("events", json.encode(encodeMap(_events)));
+            });
+            // Navigator.push(
+            // context,
+            // MaterialPageRoute(builder: (context) => Test()),
+            // );
           }),
     );
   }
 
-  //what happens when the button is pressed
-  //how you add events to the screen, edit later
-  _showAddDialog() {
-    showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-                //set the controller to _eventController
-                content: TextField(
-                  controller: _eventController,
-                ),
-                actions: <Widget>[
-                  FlatButton(
-                      child: Text("Save"),
-                      onPressed: () {
-                        //simply return if no text
-                        if (_eventController.text.isEmpty) return;
-                        setState(() {
-                          //if text is in _eventController, add the text to the
-                          //list of events for that _selectedDay in particular
-                          if (_events[_controller.selectedDay] != null) {
-                            _events[_controller.selectedDay]
-                                .add(_eventController.text);
-                            //else the text for the specific day is what is
-                            //already there
-                          } else {
-                            _events[_controller.selectedDay] = [
-                              _eventController.text
-                            ];
-                          }
-                          //add any newly created events on to prefs so they
-                          //will be saved the next time the app runs
-                          prefs.setString(
-                              "events", json.encode(encodeMap(_events)));
-                          _eventController.clear();
-                          //exit the Navigator
-                          Navigator.pop(context);
-                        });
-                      })
-                ]));
-  }
-
   //turn events map into string we can use
-  Map<String, dynamic> encodeMap(Map<DateTime, dynamic> map) {
+  Map<String, dynamic> encodeMap(Map<DateTime, Map<String, int>> map) {
     Map<String, dynamic> newMap = {};
+    print("Encode Map");
     map.forEach((key, value) {
+      print("Key $key");
+      print("Value $value");
       newMap[key.toString()] = map[key];
     });
     return newMap;
   }
 
-  Map<DateTime, dynamic> decodeMap(Map<String, dynamic> map) {
-    Map<DateTime, dynamic> newMap = {};
+  Map<DateTime, Map<String, int>> decodeMap(Map<String, dynamic> map) {
+    Map<DateTime, Map<String, int>> newMap = {};
+    print("Decode Map");
     map.forEach((key, value) {
-      newMap[DateTime.parse(key)] = map[key];
+      print("Key $key");
+      print("Value $value");
+      newMap[DateTime.parse(key)] = Map<String, int>.from(map[key]);
     });
     return newMap;
   }

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -10,12 +10,12 @@ class Home extends StatefulWidget {
 class _HomeState extends State<Home> {
   //create calendar object
   CalendarController _controller;
-  //create list of events (map type)
+  // Map of date to emotion data map
   Map<DateTime, Map<String, int>> _events;
   //creates controller for add button
   TextEditingController _eventController;
-  //creates list for the events of a specific day
-  List<dynamic> _selectedEvents;
+  // Selected emotion data for the current day
+  Map<String, int> _selectedEvents;
   //creates storage for events (data persistence)
   SharedPreferences prefs;
 
@@ -26,7 +26,7 @@ class _HomeState extends State<Home> {
     _controller = CalendarController();
     _eventController = TextEditingController();
     _events = {};
-    _selectedEvents = [];
+    _selectedEvents = {};
     initPrefs();
   }
 
@@ -53,8 +53,7 @@ class _HomeState extends State<Home> {
             //put the calendar on the screen
             TableCalendar(
               // Currently very ugly
-              events: _events
-                  .map((key, value) => MapEntry(key, [value.toString()])),
+              events: _events.map((key, value) => MapEntry(key, [value])),
               //sets calendar style
               calendarStyle:
                   CalendarStyle(selectedColor: Theme.of(context).primaryColor),
@@ -63,13 +62,17 @@ class _HomeState extends State<Home> {
               //use outside of this function
               onDaySelected: (date, events) {
                 setState(() {
-                  _selectedEvents = events;
+                  // Our map wrapped in a list of length 1 to work with calendar
+                  _selectedEvents = events.isEmpty ? {} : events[0];
                 });
               },
             ),
             //lists out the _selectedEvents (events of the day) on the screen
             //below the calendar
-            ..._selectedEvents.map((event) => ListTile(title: Text(event)))
+            ListTile(
+                title: Text(_selectedEvents.isEmpty
+                    ? "No data"
+                    : _selectedEvents.toString())),
           ],
         ),
       ),
@@ -80,14 +83,14 @@ class _HomeState extends State<Home> {
           hoverColor: Colors.blue,
           onPressed: () {
             print(_controller.selectedDay);
-            setState(() {
-              _events[_controller.selectedDay] = {"anxiety": 5, "sadness": 3};
-              prefs.setString("events", json.encode(encodeMap(_events)));
-            });
-            // Navigator.push(
-            // context,
-            // MaterialPageRoute(builder: (context) => Test()),
-            // );
+            // setState(() {
+            //   _events[_controller.selectedDay] = {"anxiety": 5, "sadness": 3};
+            //   prefs.setString("events", json.encode(encodeMap(_events)));
+            // });
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => Test(_selectedEvents)),
+            );
           }),
     );
   }

--- a/lib/quiz.dart
+++ b/lib/quiz.dart
@@ -1,55 +1,51 @@
 part of my_library;
 
 class Test extends StatefulWidget {
+  final Map<String, int> emotionData;
+
+  Test(this.emotionData) {
+    print("Received existing quiz data:");
+    print(emotionData);
+  }
+
   @override
   _TestState createState() => _TestState();
 }
 
 class _TestState extends State<Test> {
-  int numButtons = 5;
-  var emotionData;
-  var keyList;
+  static const int numButtons = 5;
+  // keyList dictates questions available and what order
+  static const List<String> keyList = [
+    'anxiety',
+    'sadness',
+    'numbness',
+    'anger',
+    'stress',
+    'happiness',
+    'tiredness',
+    'hopelessness'
+  ];
 
-  void initState() {
-    //map that stores data about each emotion's intensity
-    emotionData = {
-      'anxiety': 0,
-      'sadness': 0,
-      'numbness': 0,
-      'anger': 0,
-      'stress': 0,
-      'happiness': 0,
-      'tiredness': 0,
-      'hopelessness': 0,
-    };
-    //list that stores the keys (the emotions the quiz asks about)
-    keyList = emotionData.entries.toList();
-  }
-
-  //builds the quiz interface
+  /// Builds the quiz interface
   Widget _buildQuiz() {
     return ListView.builder(
         padding: EdgeInsets.all(16.0),
-        //create enough sections for the questions and buttons
-        itemCount: emotionData.length * 2,
+        itemCount: keyList.length,
         itemBuilder: (context, i) {
-          //alternate sections between questions and buttons
-          if (i.isEven) {
-            //question sections, i ~/ 2 since itemCount is passed into i
-            return ListTile(
-                title: Text(
-                    'How intense are your feelings of ${keyList[i ~/ 2].key} today?'));
-          } else {
-            //button sections
-            return Row(
+          var emotion = keyList[i];
+          return Column(children: <Widget>[
+            ListTile(
+                title:
+                    Text('How intense are your feelings of $emotion today?')),
+            Row(
                 mainAxisAlignment: MainAxisAlignment.center,
-                children: _buildButtons(i ~/ 2));
-          }
+                children: _buildButtons(emotion)),
+          ]);
         });
   }
 
-  //builds the buttons
-  List<Widget> _buildButtons(index) {
+  /// Builds buttons for [emotion] scale
+  List<Widget> _buildButtons(emotion) {
     //list to keep track of the buttons
     List<Widget> buttons = new List(numButtons);
     for (var i = 0; i < numButtons; i++) {
@@ -58,10 +54,12 @@ class _TestState extends State<Test> {
           onPressed: () => setState(() {
                 //if the button is pressed, change emotionData to the
                 //right intensity
-                emotionData[keyList[index].key] = i + 1;
+                // widget.emotionData[keyList[index].key] = i + 1;
+                print("Want to set $emotion to ${i + 1}");
               }),
           //change the color of the buttons to fit the information in emotionData
-          color: (i < emotionData[keyList[index].key])
+          // ?? 0 for data that isn't set yet
+          color: (i < (widget.emotionData[emotion] ?? 0))
               ? Colors.orange
               : Colors.grey));
     }

--- a/lib/quiz.dart
+++ b/lib/quiz.dart
@@ -1,11 +1,12 @@
 part of my_library;
 
 class Test extends StatefulWidget {
-  final Map<String, int> emotionData;
+  final Map<String, int> existingData;
+  final void Function(Map<String, int>) saveEmotionsCallback;
 
-  Test(this.emotionData) {
+  Test({@required this.existingData, this.saveEmotionsCallback}) {
     print("Received existing quiz data:");
-    print(emotionData);
+    print(existingData);
   }
 
   @override
@@ -25,6 +26,15 @@ class _TestState extends State<Test> {
     'tiredness',
     'hopelessness'
   ];
+
+  // Holds this quiz data (save on exit)
+  Map<String, int> emotionData;
+
+  @override
+  void initState() {
+    super.initState();
+    emotionData = {...widget.existingData}; // Could use other defaults as well
+  }
 
   /// Builds the quiz interface
   Widget _buildQuiz() {
@@ -52,16 +62,12 @@ class _TestState extends State<Test> {
       buttons[i] = (new IconButton(
           icon: new Icon(Icons.brightness_1),
           onPressed: () => setState(() {
-                //if the button is pressed, change emotionData to the
-                //right intensity
-                // widget.emotionData[keyList[index].key] = i + 1;
-                print("Want to set $emotion to ${i + 1}");
+                emotionData[emotion] = i + 1;
               }),
           //change the color of the buttons to fit the information in emotionData
           // ?? 0 for data that isn't set yet
-          color: (i < (widget.emotionData[emotion] ?? 0))
-              ? Colors.orange
-              : Colors.grey));
+          color:
+              (i < (emotionData[emotion] ?? 0)) ? Colors.orange : Colors.grey));
     }
     return buttons;
   }
@@ -71,6 +77,14 @@ class _TestState extends State<Test> {
     return new Scaffold(
         appBar: new AppBar(
           title: new Text('Daily Check-In'),
+          actions: <Widget>[
+            IconButton(
+                icon: Icon(Icons.check),
+                onPressed: () {
+                  widget.saveEmotionsCallback(emotionData);
+                  Navigator.pop(context);
+                }),
+          ],
         ),
         body: _buildQuiz());
   }


### PR DESCRIPTION
In this pull request, I converted the calendar's data structure to a type suitable for emotion data, mapping DateTime to a map of String (emotion name) to int (emotion value). Existing emotion data for the selected day is also passed to the quiz, allowing the user to modify their emotion data or adjust it later. At the moment, only data explicitly entered is stored, i.e. if no rating 1-5 is selected that emotion is not included in the final result. Other elements of the app such as the graph should not expect a certain set of hard-coded emotions, but should use any emotions available. The emotion keys are currently in the Quiz, though they can be moved elsewhere as necessary. I also added a save button to the quiz, and when it is pressed the quiz's data is passed back and saved to the calendar. Finally, I refactored the main data storage from the calendar on the "home" screen to the main.dart file so it can be used by other parts of the program. This was done with callbacks, but other solutions can be explored.